### PR TITLE
fix: Fix typo in documentation

### DIFF
--- a/docs/src/tutorial/handling_disconnection.md
+++ b/docs/src/tutorial/handling_disconnection.md
@@ -157,7 +157,7 @@ async fn accept_loop(addr: impl ToSocketAddrs) -> Result<()> {
         spawn_and_log_error(connection_loop(broker_sender.clone(), stream));
     }
     drop(broker_sender);
-    broker_handle.await?;
+    broker_handle.await;
     Ok(())
 }
 


### PR DESCRIPTION
Hi, i was going through the doc and saw this example which did not compile. 
Went to https://github.com/async-rs/async-std/blob/master/examples/a-chat/server.rs#L38 and saw that there was actually a typo between the doc and the working example.

By the way, thanks for the cool stuff in this lib.